### PR TITLE
PIE-4138 add custom handlers

### DIFF
--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -493,6 +493,7 @@ def load_logging_config(
     root_logger = logging.getLogger()
     root_logger.handlers = []
     root_logger.addHandler(stream_handler)
+    custom_handlers = custom_handlers or []
     for handler in custom_handlers:
         root_logger.addHandler(handler)
 

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -4,13 +4,13 @@
 
 import json
 import logging
-from logging import Handler
 import os
 import socket
 import sys
 import warnings
 from collections import defaultdict
 from functools import partial
+from logging import Handler
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import pkg_resources
@@ -435,7 +435,7 @@ class HostNameProcessor(BaseProcessor):
 def load_logging_config(
     custom_processors: List[BaseProcessor] = None,
     custom_handlers: List[Handler] = None,
-    use_hostname_processor: bool = True
+    use_hostname_processor: bool = True,
 ) -> logging.Logger:
     """Load the different logging config parameters as defined in the config of the application.
 

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+from logging import Handler
 import os
 import socket
 import sys
@@ -432,12 +433,15 @@ class HostNameProcessor(BaseProcessor):
 
 
 def load_logging_config(
-    custom_processors: List[BaseProcessor] = None, use_hostname_processor: bool = True
+    custom_processors: List[BaseProcessor] = None,
+    custom_handlers: List[Handler] = None,
+    use_hostname_processor: bool = True
 ) -> logging.Logger:
     """Load the different logging config parameters as defined in the config of the application.
 
     Args:
         custom_processors: List of custom processors for log records
+        custom_handlers: List of custom handlers to log records
         use_hostname_processor: Use the built-in HostNameProcessor for log records
 
     Returns:
@@ -489,6 +493,8 @@ def load_logging_config(
     root_logger = logging.getLogger()
     root_logger.handlers = []
     root_logger.addHandler(handler)
+    for h in custom_handlers:
+        root_logger.addHandler(h)
     root_logger.setLevel(config.logging.min_level)
 
     # Add override for other loggers, usually loggers from libraries

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -487,14 +487,15 @@ def load_logging_config(
         foreign_pre_chain=shared_processors,
     )
 
-    handler = logging.StreamHandler(stream=sys.stdout)
-    handler.setFormatter(formatter)
+    stream_handler = logging.StreamHandler(stream=sys.stdout)
+    stream_handler.setFormatter(formatter)
 
     root_logger = logging.getLogger()
     root_logger.handlers = []
-    root_logger.addHandler(handler)
-    for h in custom_handlers:
-        root_logger.addHandler(h)
+    root_logger.addHandler(stream_handler)
+    for handler in custom_handlers:
+        root_logger.addHandler(handler)
+
     root_logger.setLevel(config.logging.min_level)
 
     # Add override for other loggers, usually loggers from libraries

--- a/tests/configurator_test.py
+++ b/tests/configurator_test.py
@@ -174,6 +174,22 @@ def test_load_logging_config_with_custom_processor():
         assert custom_processor_1 in stream_handler.formatter.foreign_pre_chain
 
 
+def test_load_logging_config_with_custom_handler():
+    class CustomHandler(logging.Handler):
+        def __init__(self):
+            logging.Handler.__init__(self)
+
+        def emit(self, record):
+            print(record)
+
+    with mock_config_file(mock_default_config):
+        setup_config("fake-tool", "project.config", critical_settings=False, setup_logging=False, reload_config=True)
+        logger = load_logging_config(custom_handlers=[CustomHandler()])
+        assert len(logger.handlers) == 2
+        assert type(logger.handlers[0]) == logging.StreamHandler
+        assert type(logger.handlers[1]) == CustomHandler
+
+
 @clear_env_vars
 def test_setup_config_unit_test_with_test_config():
     os.environ["FAKE_TOOL_APP_SECRET_KEY"] = "Quatre-Roue-Force"


### PR DESCRIPTION
This will allow the servers to use custom log handlers, by doing it like it's currently done for custom processors in the app.py.
`load_logging_config(custom_processors=custom_processors, custom_handlers=custom_handlers)`