### PR TITLE
Pie 4813 full override on empty dict

### DIFF
--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -169,7 +169,11 @@ class Config:
                 if isinstance(override_value, dict):
                     if base_config[key] is None:
                         base_config[key] = {}
-                    base_config[key] = self._merge_configs(base_config[key], override_value, next_path)
+                    if override_value == {}:
+                        # if the override is an empty dict, don't proceed to a merge, plainly override
+                        base_config[key] = {}
+                    else:
+                        base_config[key] = self._merge_configs(base_config[key], override_value, next_path)
                 else:
                     base_config[key] = override_value
             elif len(current_path) > 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opset"
-version = "2.1.0"
+version = "2.1.1"
 description = "A library for simplifying the configuration of Python applications at all stages of deployment."
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/configurator_test.py
+++ b/tests/configurator_test.py
@@ -202,10 +202,13 @@ def test_setup_config_unit_test_with_test_config():
     with mock_config_file(
         mock_default_config, unit_test_values={"app": {"api_key": "ma clef!"}, "logging": {"disable_processors": True}}
     ):
-        setup_unit_test_config("fake_tool", "project.config", config_values={"app": {"secret_key": "pirate!"}})
+        setup_unit_test_config(
+            "fake_tool", "project.config", config_values={"app": {"secret_key": "pirate!"}, "level1": {}}
+        )
         assert config.logging.disable_processors is True  # unit_test trumps default
         assert config.app.api_key == "Beton"  # env variables trump unit test
         assert config.app.secret_key == "pirate!"  # values passed during init trump values from env variables
+        assert config.level1 == {}  # complete override rather than merge when passing an empty dict
 
 
 @clear_env_vars


### PR DESCRIPTION
Fix a behaviour change introduced in 2.0.0 where overriding with an empty dictionary no longer overrides.

Before opening a PR, make sure that, if relevant:
- [x] Changes are covered by automated tests.
- [x] New / updated functions / methods have typehints.
- [x] READMEs have been updated.
- [x] The affected parties are / will be notified of incoming breaking changes.

cc @MarcDufresne @ajutras 
